### PR TITLE
Add forget password feature

### DIFF
--- a/conote-frontend/src/App.tsx
+++ b/conote-frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Home from "./components/Home";
 import Login from "./components/user/Login";
 import Signup from "./components/user/Signup";
 import Dashboard from "./components/user/Dashboard";
+import Forgetpassword from "./components/user/Forgetpassword";
 import {
   BrowserRouter,
   Routes,
@@ -49,6 +50,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="login" element={<Login />} />
             <Route path="signup" element={<Signup />} />
+            <Route path="forget_password" element={<Forgetpassword />} />
           </Route>
           <Route path="editor" element={<Editor />} />
           <Route

--- a/conote-frontend/src/components/user/Forgetpassword.tsx
+++ b/conote-frontend/src/components/user/Forgetpassword.tsx
@@ -11,42 +11,10 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useProvideAuth } from "hooks/useAuth";
 
-function Forgetpasswordform(props: any) {
-  const [email, setEmail] = useState("");
-
-  return (
-    <VStack
-      boxShadow="base"
-      borderRadius="md"
-      padding="7"
-      spacing="5"
-      w="70vw"
-      minW="340px"
-      maxW="lg"
-    >
-      <FormControl id="email">
-        <FormLabel htmlFor="email">Email address</FormLabel>
-        <Input
-          onChange={(e) => setEmail(e.target.value)}
-          type="email"
-          placeholder="johndoe@example.com"
-        />
-      </FormControl>
-      <Button
-        onClick={() => props.onButtonClick(email)}
-        colorScheme="blue"
-        boxShadow="base"
-        padding="0px 1.5em"
-      >
-        {props.buttonValue}
-      </Button>
-    </VStack>
-  );
-}
-
 export default function Forgetpassword() {
   const navigate = useNavigate();
   const authentication = useProvideAuth();
+  const [email, setEmail] = useState("");
 
   return (
     <Flex minH={"100vh"} align={"center"} justify={"center"}>
@@ -54,13 +22,37 @@ export default function Forgetpassword() {
         <Heading size="3xl" fontFamily="League Spartan">
           Reset Password
         </Heading>
-        <Forgetpasswordform
-          onButtonClick={(email: string) => {
-            authentication.sendPwdResetEmail(email)
-              .catch(error => console.log(error));
-          }}
-          buttonValue={"Recover"}
-        />
+        <VStack
+          boxShadow="base"
+          borderRadius="md"
+          padding="7"
+          spacing="5"
+          w="70vw"
+          minW="340px"
+          maxW="lg"
+        >
+          <FormControl id="email">
+            <FormLabel htmlFor="email">Email address</FormLabel>
+            <Input
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              type="email"
+              placeholder="johndoe@example.com"
+            />
+          </FormControl>
+          <Button
+            onClick={() => {
+              authentication.sendPwdResetEmail(email)
+                .then(response => setEmail(""))
+                .catch(error => console.log(error));
+            }}
+            colorScheme="blue"
+            boxShadow="base"
+            padding="0px 1.5em"
+          >
+            Recover
+          </Button>
+        </VStack>
       </VStack>
     </Flex>
   );

--- a/conote-frontend/src/components/user/Forgetpassword.tsx
+++ b/conote-frontend/src/components/user/Forgetpassword.tsx
@@ -1,0 +1,67 @@
+import {
+  Heading,
+  VStack,
+  Flex,
+  FormControl,
+  FormLabel,
+  Input,
+  Button,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useProvideAuth } from "hooks/useAuth";
+
+function Forgetpasswordform(props: any) {
+  const [email, setEmail] = useState("");
+
+  return (
+    <VStack
+      boxShadow="base"
+      borderRadius="md"
+      padding="7"
+      spacing="5"
+      w="70vw"
+      minW="340px"
+      maxW="lg"
+    >
+      <FormControl id="email">
+        <FormLabel htmlFor="email">Email address</FormLabel>
+        <Input
+          onChange={(e) => setEmail(e.target.value)}
+          type="email"
+          placeholder="johndoe@example.com"
+        />
+      </FormControl>
+      <Button
+        onClick={() => props.onButtonClick(email)}
+        colorScheme="blue"
+        boxShadow="base"
+        padding="0px 1.5em"
+      >
+        {props.buttonValue}
+      </Button>
+    </VStack>
+  );
+}
+
+export default function Forgetpassword() {
+  const navigate = useNavigate();
+  const authentication = useProvideAuth();
+
+  return (
+    <Flex minH={"100vh"} align={"center"} justify={"center"}>
+      <VStack spacing="6">
+        <Heading size="3xl" fontFamily="League Spartan">
+          Reset Password
+        </Heading>
+        <Forgetpasswordform
+          onButtonClick={(email: string) => {
+            authentication.sendPwdResetEmail(email)
+              .catch(error => console.log(error));
+          }}
+          buttonValue={"Recover"}
+        />
+      </VStack>
+    </Flex>
+  );
+}


### PR DESCRIPTION
Notes:
- The reset password link sent to the email is still using the Firebase default landing page. This should be changed in the future.
- The `Recover` button on the forget password page has no feedback/prompt on whether the email has been sent or not. This should be resolved in #21.