### PR TITLE
Add button to add/edit tags for documents

### DIFF
--- a/conote-frontend/src/components/user/DocCard.tsx
+++ b/conote-frontend/src/components/user/DocCard.tsx
@@ -100,18 +100,17 @@ function EditTagsButton({ docID, title, ...props }: any) {
   const [input, setInput] = useState("");
   const [tagError, setTagError] = useState("");
 
-  const handleTagDelete = (value: string) => {
-    if (tags.includes(value)) {
-      setTags(tags.filter(x => x !== value));
-    }
-  };
-
-  const onSave = (e: any) => {
+  useEffect(() => {
     if (!auth.user) return;
     update(ref(getDatabase(), `docs/${docID}`), {
       tags: tags
     });
-    onClose();
+  }, [tags]);
+
+  const handleTagDelete = (value: string) => {
+    if (tags.includes(value)) {
+      setTags(tags.filter(x => x !== value));
+    }
   };
 
   return (
@@ -190,7 +189,9 @@ function EditTagsButton({ docID, title, ...props }: any) {
                         if (tags.length === 0) {
                           setTagError("No tags to delete");
                         } else {
-                          handleTagDelete(tags[tags.length - 1]);
+                          let lastTag = tags[tags.length - 1];
+                          handleTagDelete(lastTag);
+                          setInput(lastTag);
                           setTagError("");
                         }
                       }
@@ -214,11 +215,8 @@ function EditTagsButton({ docID, title, ...props }: any) {
             </FormControl>
           </ModalBody>
           <ModalFooter>
-            <Button onClick={onClose} mr="3">
-              Cancel
-            </Button>
-            <Button colorScheme="blue" onClick={onSave}>
-              Save
+            <Button colorScheme="blue" onClick={onClose}>
+              Close
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/conote-frontend/src/components/user/DocCard.tsx
+++ b/conote-frontend/src/components/user/DocCard.tsx
@@ -173,12 +173,12 @@ function EditTagsButton({ docID, title, ...props }: any) {
                     case 'Tab':
                     case 'Enter':
                     case ',':
+                      e.preventDefault();
                       if (value.length === 0) {
                         setTagError("Empty tag");
                       } else if (tags.includes(value)) {
                         setTagError("Tag already exists");
                       } else {
-                        e.preventDefault();
                         setInput("");
                         setTags(tags => [...tags, value]);
                         setTagError("");
@@ -186,6 +186,7 @@ function EditTagsButton({ docID, title, ...props }: any) {
                       break;
                     case 'Backspace':
                       if (value.length === 0) {
+                        e.preventDefault();
                         if (tags.length === 0) {
                           setTagError("No tags to delete");
                         } else {


### PR DESCRIPTION
Notes:
- Tags are keyed to documents; i.e., all users seeing the same document will see the same tags.
- Press `Enter`, `Tab`, or `,` to add the text in the input box as a tag.
- Press `Backspace` when the input box is empty to delete the last (rightmost) tag. Then, the input box will contain the deleted tag.
- The database is updated every time a tag is created or deleted.
- Aesthetics should be improved.
- In the future, maybe add drag functionality to each tag to be able to reorder them?