### PR TITLE
Adds menu to set access levels for documents

### DIFF
--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -82,12 +82,15 @@ const Editor = () => {
         EditorView.lineWrapping,
         EditorView.updateListener.of((update) => {
           if (update.changes) {
+            setDocContent(update.state.doc.toString());
+          }
+
+          if (update.docChanged) {
             // Only update timestamp every second.
             if (Date.now() - lastSecond >= 1_000) {
               set(ref(getDatabase(), docRef + "/timestamp"), serverTimestamp());
               lastSecond = Date.now();
             }
-            setDocContent(update.state.doc.toString());
           }
         }),
       ],

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -48,7 +48,8 @@ const Editor = () => {
   const [available, setAvailable] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!editorRef.current) return;
+    // TODO: Assumes editor is signed in, what if not the case?
+    if (!editorRef.current || !auth.user) return;
 
     let docRef = "debug_doc";
 
@@ -103,6 +104,7 @@ const Editor = () => {
       view,
       {
         defaultText: "",
+        userId: auth.user.uid,
       }
     );
 

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -19,7 +19,7 @@ import Firepad from "@lucafabbian/firepad";
 
 import { useProvideAuth } from "hooks/useAuth";
 import { compatApp } from "config/firebaseConfig";
-import { get, getDatabase, ref } from "firebase/database";
+import { set, get, getDatabase, ref, serverTimestamp } from "firebase/database";
 import firebase from "firebase/compat/app";
 import "firebase/compat/database";
 
@@ -73,6 +73,8 @@ const Editor = () => {
       // TODO: Not authenticated case is not yet done.
     }
 
+    let lastSecond: number = 0;
+
     const view = new EditorView({
       extensions: [
         basicSetup,
@@ -80,6 +82,11 @@ const Editor = () => {
         EditorView.lineWrapping,
         EditorView.updateListener.of((update) => {
           if (update.changes) {
+            // Only update timestamp every second.
+            if (Date.now() - lastSecond >= 1_000) {
+              set(ref(getDatabase(), docRef + "/timestamp"), serverTimestamp());
+              lastSecond = Date.now();
+            }
             setDocContent(update.state.doc.toString());
           }
         }),
@@ -110,7 +117,7 @@ const Editor = () => {
 
   return (
     <Box minH="100vh">
-      <EditorNavbar />
+      <EditorNavbar docID={params.docID} />
       <HStack
         paddingX="2"
         marginTop="20px"

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -58,7 +58,6 @@ const Editor = () => {
         get(ref(getDatabase(), docRef + "/roles/" + auth.user.uid))
           .then((snapshot) => {
             if (!snapshot.exists() || snapshot.val() === "viewer") {
-              console.log("Wut1");
               navigate("/error/403");
             }
           })

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -23,6 +23,8 @@ import { get, getDatabase, ref } from "firebase/database";
 import firebase from "firebase/compat/app";
 import "firebase/compat/database";
 
+import EditorNavbar from "./EditorNavbar";
+
 function MarkdownPreview({ docContent, ...props }: any) {
   return (
     <>
@@ -107,21 +109,11 @@ const Editor = () => {
   }, [editorRef.current, auth.user]);
 
   return (
-    <VStack padding="1">
-      <Link
-        color="gray.400"
-        _hover={{
-          textColor: "gray.600",
-          textDecoration: "underline",
-        }}
-        as={RouteLink}
-        to="/"
-      >
-        &#60; Return home.
-      </Link>
+    <Box minH="100vh">
+      <EditorNavbar />
       <HStack
-        w="100vw"
-        padding="2"
+        paddingX="2"
+        marginTop="20px"
         verticalAlign="top"
         textAlign="left"
         h="90vh"
@@ -140,7 +132,7 @@ const Editor = () => {
           </Box>
         </VStack>
       </HStack>
-    </VStack>
+    </Box>
   );
 };
 

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -1,0 +1,28 @@
+import { HStack, Flex } from "@chakra-ui/react";
+
+import { Link as RouteLink } from "react-router-dom";
+import NavbarContainer from "components/NavbarContainer";
+import Logo from "components/Logo";
+import UserButton from "components/user/UserButton";
+
+export default function EditorNavbar(props: any) {
+  return (
+    <NavbarContainer>
+      <Logo
+        fontSize="24pt"
+        marginBottom="-0.4em"
+        transition="transform 100ms linear"
+        _hover={{
+          transform: "scale(1.05)",
+        }}
+        as={RouteLink}
+        to="/"
+      />
+      <HStack spacing="4">
+        <Flex align="center">
+          <UserButton />
+        </Flex>
+      </HStack>
+    </NavbarContainer>
+  );
+}

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -1,11 +1,46 @@
-import { HStack, Flex } from "@chakra-ui/react";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  PopoverFooter,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverAnchor,
+  HStack,
+  Heading,
+  Flex,
+  IconButton,
+} from "@chakra-ui/react";
 
 import { Link as RouteLink } from "react-router-dom";
 import NavbarContainer from "components/NavbarContainer";
 import Logo from "components/Logo";
 import UserButton from "components/user/UserButton";
+import { IoShare } from "react-icons/io5";
 
-export default function EditorNavbar(props: any) {
+function DocShareButton({ docID, ...props }: any) {
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <IconButton
+          colorScheme="blue"
+          variant="ghost"
+          icon={<IoShare />}
+          aria-label="share document"
+        />
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverHeader>
+          <Heading size="md">Share Note</Heading>
+        </PopoverHeader>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default function EditorNavbar({ docID, ...props }: any) {
   return (
     <NavbarContainer>
       <Logo
@@ -20,8 +55,9 @@ export default function EditorNavbar(props: any) {
       />
       <HStack spacing="4">
         <Flex align="center">
-          <UserButton />
+          <DocShareButton docID={docID} />
         </Flex>
+        <UserButton />
       </HStack>
     </NavbarContainer>
   );

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -1,4 +1,7 @@
 import {
+  FormControl,
+  FormLabel,
+  FormHelperText,
   Popover,
   PopoverTrigger,
   PopoverContent,
@@ -12,17 +15,169 @@ import {
   Heading,
   Flex,
   IconButton,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  Select,
+  Table,
+  Thead,
+  Tbody,
+  Tfoot,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Text,
+  FormErrorMessage,
+  Box,
+  useToast,
 } from "@chakra-ui/react";
 
+import { useEffect, useState } from "react";
 import { Link as RouteLink } from "react-router-dom";
 import NavbarContainer from "components/NavbarContainer";
 import Logo from "components/Logo";
 import UserButton from "components/user/UserButton";
 import { IoShare } from "react-icons/io5";
 
-function DocShareButton({ docID, ...props }: any) {
+import { get, set, onValue, getDatabase, ref } from "firebase/database";
+import { useProvideAuth } from "hooks/useAuth";
+
+function validateEmail(email: string) {
+  return email.match(
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  );
+}
+
+function DeleteUserRoleButton({ uid, docID, ...props }: any) {}
+
+function AddCollaboratorForm({ docID, ...props }: any) {
+  const toast = useToast();
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("editor");
+
+  const onSubmit = () => {
+    if (validateEmail(email)) {
+      let filteredEmail = email.toLowerCase().replaceAll(".", ",");
+      get(ref(getDatabase(), `email_to_uid/${filteredEmail}`)).then(
+        (snapshot) => {
+          if (!snapshot.exists()) {
+            toast({
+              title: "Error",
+              description:
+                "We can't find the e-mail in our database. Please make sure you entered the correct e-mail. (Milestone 2 note: In case of issues due to mismatched database structures, try logging in to the e-mail to be collaborated to fix this issue)",
+              status: "error",
+              duration: 8_000,
+              isClosable: true,
+            });
+          } else {
+            toast({
+              title: "Success",
+              description: "UID: " + snapshot.val(),
+              status: "success",
+              duration: 5_000,
+              isClosable: true,
+            });
+          }
+        }
+      );
+    } else {
+      toast({
+        title: "Error",
+        description:
+          "The e-mail you entered is invalid. Please enter a valid e-mail",
+        status: "error",
+        duration: 5_000,
+        isClosable: true,
+      });
+    }
+  };
+
   return (
-    <Popover>
+    <FormControl paddingX="1">
+      <InputGroup
+        size="sm"
+        variant="flushed"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            onSubmit();
+          }
+        }}
+      >
+        <Input
+          placeholder="Collaborator's e-mail here"
+          size="sm"
+          variant="flushed"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+        ></Input>
+        <InputRightAddon w="25%">
+          <Select
+            size="sm"
+            variant="flushed"
+            value={role}
+            onChange={(e) => {
+              setRole(e.target.value);
+            }}
+          >
+            <option value="editor">Editor</option>
+            <option value="viewer">Viewer</option>
+          </Select>
+        </InputRightAddon>
+      </InputGroup>
+      <Box mt="-5px">
+        <FormErrorMessage fontSize="xs"></FormErrorMessage>
+        <FormHelperText fontSize="xs">
+          Press enter to add a collaborator.
+        </FormHelperText>
+      </Box>
+    </FormControl>
+  );
+}
+
+function DocShareButton({ docID, ...props }: any) {
+  const auth = useProvideAuth();
+  const [docRoles, setDocRoles] = useState<any>();
+  const [isOwner, setIsOwner] = useState<boolean>(false);
+
+  // Effect to get user roles.
+  useEffect(() => {
+    const unsub = onValue(
+      ref(getDatabase(), `docs/${docID}/roles`),
+      (snapshot) => {
+        let snapvar = snapshot.val();
+        setDocRoles(
+          Object.keys(snapvar).map((key, i) => {
+            return [
+              key,
+              key,
+              snapvar[key].charAt(0).toUpperCase() + snapvar[key].slice(1),
+            ];
+          })
+        );
+        if (auth.user && snapvar[auth.user.uid] === "owner") {
+          setIsOwner(true);
+        }
+        for (const x in snapvar) {
+          get(ref(getDatabase(), `users/${x}/fullname`)).then((snapshot) => {
+            setDocRoles((val: any) => {
+              return val.map((element: any) => {
+                if (element[0] === x)
+                  return [element[0], snapshot.val(), element[2]];
+                else return element;
+              });
+            });
+          });
+        }
+      }
+    );
+    return () => unsub();
+  }, [auth.user, docID]);
+
+  return (
+    <Popover placement="bottom-end">
       <PopoverTrigger>
         <IconButton
           colorScheme="blue"
@@ -31,10 +186,44 @@ function DocShareButton({ docID, ...props }: any) {
           aria-label="share document"
         />
       </PopoverTrigger>
-      <PopoverContent>
+      <PopoverContent w="md">
+        <PopoverArrow />
         <PopoverHeader>
           <Heading size="md">Share Note</Heading>
         </PopoverHeader>
+        <PopoverBody textAlign="left">
+          <Text fontSize="xs" mb={1} textColor="blue.500">
+            <b>Collaborators</b>
+          </Text>
+          <TableContainer>
+            <Table size="sm">
+              <Thead>
+                <Th>User</Th>
+                <Th>Role</Th>
+                <Th></Th>
+              </Thead>
+              <Tbody>
+                {docRoles !== undefined &&
+                  Object.keys(docRoles).map((key, i) => {
+                    return (
+                      <Tr>
+                        <Td>
+                          <b>{docRoles[key][1]}</b>
+                        </Td>
+                        <Td>{docRoles[key][2]}</Td>
+                        <Td></Td>
+                      </Tr>
+                    );
+                  })}
+              </Tbody>
+            </Table>
+
+            <Text fontSize="xs" mt={4} mb={2} textColor="blue.500">
+              <b>Add Collaborators</b>
+            </Text>
+            <AddCollaboratorForm />
+          </TableContainer>
+        </PopoverBody>
       </PopoverContent>
     </Popover>
   );

--- a/conote-frontend/src/components/interfaces/userType.tsx
+++ b/conote-frontend/src/components/interfaces/userType.tsx
@@ -1,5 +1,6 @@
 export default interface userType {
   fullname: string;
   img_url: string;
+  email: string;
   owned_documents: any;
 }

--- a/conote-frontend/src/components/interfaces/userType.tsx
+++ b/conote-frontend/src/components/interfaces/userType.tsx
@@ -1,6 +1,5 @@
 export default interface userType {
   fullname: string;
   img_url: string;
-  email: string;
   owned_documents: any;
 }

--- a/conote-frontend/src/hooks/useAuth.tsx
+++ b/conote-frontend/src/hooks/useAuth.tsx
@@ -18,6 +18,7 @@ import {
 import {
   getDatabase,
   ref,
+  get,
   set,
   DataSnapshot,
   onValue,
@@ -46,12 +47,29 @@ export function useProvideAuth() {
   // Wrap any Firebase methods we want to use making sure ...
   // ... to save the user to state.
   const signin = (email: string, password: string) => {
-    return signInWithEmailAndPassword(auth, email, password).then(
-      (response) => {
+    return signInWithEmailAndPassword(auth, email, password)
+      .then((response) => {
         setUser(response.user);
         return response.user;
-      }
-    );
+      })
+      .then((user) => {
+        get(ref(getDatabase(), `users/${user.uid}`)).then((snapshot) => {
+          let snapvar = snapshot.val();
+          // TODO: Better solutions definitely exist, but autopopulating the fields works for now.
+          if (snapvar.email === undefined) {
+            set(ref(getDatabase(), `users/${user.uid}/email`), user.email);
+          }
+          if (snapvar.fullname === undefined) {
+            set(
+              ref(getDatabase(), `users/${user.uid}/fullname`),
+              user.email || "[UNKNOWN]"
+            );
+          }
+          if (snapvar.img_url === undefined) {
+            set(ref(getDatabase(), `users/${user.uid}/img_url`), "");
+          }
+        });
+      });
   };
   const signup = (email: string, password: string, props: any) => {
     return createUserWithEmailAndPassword(auth, email, password)
@@ -63,9 +81,10 @@ export function useProvideAuth() {
         set(ref(getDatabase(), `users/${user.uid}`), {
           fullname: props.fullname,
           img_url: "",
+          email: user.email,
           owned_documents: {},
         }).catch((e) => {
-          console.log("Set Error: " + e); // TODO: Alert notification?
+          console.log("SetUserData Error: " + e); // TODO: Alert notification?
         });
       });
   };
@@ -94,10 +113,10 @@ export function useProvideAuth() {
         }
         setUserData(snapvar);
       } else {
-        // TOTHINK: Currently auto-populates the database with default values if user is not in database. Maybe change?
         set(ref(getDatabase(), `users/${user.uid}`), {
-          fullname: user.email || "John Doe",
+          fullname: user.email || "[UNKNOWN]",
           img_url: "",
+          email: user.email,
           owned_documents: {},
         });
       }

--- a/conote-frontend/src/hooks/useAuth.tsx
+++ b/conote-frontend/src/hooks/useAuth.tsx
@@ -69,6 +69,17 @@ export function useProvideAuth() {
             set(ref(getDatabase(), `users/${user.uid}/img_url`), "");
           }
         });
+
+        // TODO: Only needed as this is added at a later date in comparison to the original database. A new database will no longer need this line.
+        if (user.email) {
+          set(
+            ref(
+              getDatabase(),
+              `email_to_uid/${user.email.replaceAll(".", ",")}`
+            ),
+            user.uid
+          ).catch((e) => console.log(e));
+        }
       });
   };
   const signup = (email: string, password: string, props: any) => {
@@ -81,11 +92,21 @@ export function useProvideAuth() {
         set(ref(getDatabase(), `users/${user.uid}`), {
           fullname: props.fullname,
           img_url: "",
-          email: user.email,
           owned_documents: {},
         }).catch((e) => {
           console.log("SetUserData Error: " + e); // TODO: Alert notification?
         });
+
+        if (user.email) {
+          // TODO: Solution is a bit hacky, but works for now. Could crop out as an issue later, maybe fix? (or at least filter sign-ups to not allow these id-s).
+          set(
+            ref(
+              getDatabase(),
+              `email_to_uid/${user.email.replaceAll(".", ",")}`
+            ),
+            user.uid
+          ).catch((e) => console.log("SetEmailData Error: " + e));
+        }
       });
   };
   const signout = () => {
@@ -113,10 +134,10 @@ export function useProvideAuth() {
         }
         setUserData(snapvar);
       } else {
+        // TODO: Can be deprecated soon.
         set(ref(getDatabase(), `users/${user.uid}`), {
           fullname: user.email || "[UNKNOWN]",
           img_url: "",
-          email: user.email,
           owned_documents: {},
         });
       }


### PR DESCRIPTION
Also adds:
- Document timestamp modification on document edit
- Database structure modifications to support querying UID through e-mail.

Some issues:
- On role modification, the web app currently gets all roles again because it uses the `onValue()` subscription. It also makes the interface spazz out a little as by default it loads the UID first before loading the user's fullname. This can definitely be fixed at a future date by making the more manual get-s or caching user's fullnames, but it is sufficient for now. Perhaps can be looked into later.
- Public view-able option still not available.

Closes #35 and #14.