### PR TITLE
Adds viewer interface

### DIFF
--- a/conote-frontend/package-lock.json
+++ b/conote-frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
         "@uiw/react-codemirror": "^4.8.1",
+        "chakra-ui-markdown-renderer": "^4.1.0",
         "codemirror": "^6.0.0",
         "csstype": "^3.1.0",
         "firebase": "^9.8.3",
@@ -7391,6 +7392,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chakra-ui-markdown-renderer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chakra-ui-markdown-renderer/-/chakra-ui-markdown-renderer-4.1.0.tgz",
+      "integrity": "sha512-kcRy5d2aSAEgLVvAQ3p/pMdOLY1sR6d/hOU2pl6zNXHuTzrUhjhGxEBDskyU0ffpIilsR/f1/NIAxMCXhSoREQ==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/react": "^1.6.1 || ^2",
+        "react-markdown": "^7 || ^8"
       }
     },
     "node_modules/chalk": {
@@ -26497,6 +26510,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+    },
+    "chakra-ui-markdown-renderer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chakra-ui-markdown-renderer/-/chakra-ui-markdown-renderer-4.1.0.tgz",
+      "integrity": "sha512-kcRy5d2aSAEgLVvAQ3p/pMdOLY1sR6d/hOU2pl6zNXHuTzrUhjhGxEBDskyU0ffpIilsR/f1/NIAxMCXhSoREQ==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
     },
     "chalk": {
       "version": "2.4.2",

--- a/conote-frontend/package.json
+++ b/conote-frontend/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "@uiw/react-codemirror": "^4.8.1",
+    "chakra-ui-markdown-renderer": "^4.1.0",
     "codemirror": "^6.0.0",
     "csstype": "^3.1.0",
     "firebase": "^9.8.3",

--- a/conote-frontend/src/App.tsx
+++ b/conote-frontend/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
               </RedirectRoute>
             }
           />
-          <Route path="docs/edit/:docID" element={<Editor />} />
+          <Route path="docs/:docID" element={<Editor />} />
           <Route path="error/:errorID" element={<ErrorPage />} />
           <Route
             path="*"

--- a/conote-frontend/src/components/LoadingPage.tsx
+++ b/conote-frontend/src/components/LoadingPage.tsx
@@ -1,0 +1,21 @@
+import { VStack, Spinner, Text } from "@chakra-ui/react";
+
+export default function LoadingPage({
+  msg,
+  spinnerSize,
+  fontSize,
+  ...props
+}: any) {
+  return (
+    <VStack spacing="3" {...props}>
+      <Spinner
+        size={spinnerSize || "xl"}
+        thickness="4px"
+        speed="0.65s"
+        emptyColor="gray.200"
+        color="blue.500"
+      />
+      <Text fontSize={fontSize || "xl"}>{msg || "Loading..."}</Text>
+    </VStack>
+  );
+}

--- a/conote-frontend/src/components/NavbarContainer.tsx
+++ b/conote-frontend/src/components/NavbarContainer.tsx
@@ -9,8 +9,11 @@ export default function NavbarContainer({ children, ...props }: Props) {
   return (
     <Flex
       as="nav"
+      zIndex="1"
       align="center"
       justify="space-between"
+      position="fixed"
+      top="0"
       wrap="wrap"
       w="100%"
       mb={8}
@@ -18,7 +21,7 @@ export default function NavbarContainer({ children, ...props }: Props) {
       px={{ base: 5 }}
       borderBottomWidth={1}
       borderStyle={"solid"}
-      bg={["primary.500", "primary.500", "transparent", "transparent"]}
+      bg="white"
       {...props}
     >
       {children}

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -1,5 +1,5 @@
 import { HStack, Box, VStack, Text, Spinner } from "@chakra-ui/react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import "firebase/compat/database";
@@ -15,23 +15,34 @@ const Editor = () => {
     params.docID,
     editorRef
   );
+  const [editSize, setEditSize] = useState(50);
+
+  useEffect(() => {
+    if (userRole === "viewer") {
+      setEditSize(0);
+    }
+  }, [userRole]);
 
   /* TODO: Crazy hack solution in terms of top position and calc(100vh - 73px) to get the editor dimensions exactly right.
-  Seems like a problem waiting to happen in the future...
+  Can't wait for this to break in the future
   */
   return (
     <Box maxH="100vh">
-      <EditorNavbar docID={params.docID} />
+      <EditorNavbar
+        docID={params.docID}
+        editSize={editSize}
+        setEditSize={setEditSize}
+      />
       <HStack verticalAlign="top" textAlign="left" hidden={!available}>
-        <VStack w="50%" position="fixed" top="73px">
+        <VStack w={editSize + "%"} position="fixed" top="73px">
           <Box w="100%" borderRightWidth="1px" verticalAlign="top">
             <Box ref={editorRef} />
           </Box>
         </VStack>
-        <VStack w="50%">
+        <VStack w={editSize + "%"}>
           <Box w="100%" verticalAlign="top"></Box>
         </VStack>
-        <VStack w="50%" h="100%">
+        <VStack w={100 - editSize + "%"} h="100%">
           <Box w="100%" verticalAlign="top" mt="50">
             <MarkdownPreview docContent={docContent} />
           </Box>

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -1,146 +1,22 @@
-import {
-  HStack,
-  Box,
-  VStack,
-  Text,
-  Link,
-  Spinner,
-  Flex,
-} from "@chakra-ui/react";
-import { useRef, useEffect, useState } from "react";
-import { useParams, Link as RouteLink, useNavigate } from "react-router-dom";
+import { HStack, Box, VStack, Text, Spinner } from "@chakra-ui/react";
+import { useRef } from "react";
+import { useParams } from "react-router-dom";
 
-import { EditorView, keymap } from "@codemirror/view";
-import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-import { basicSetup } from "codemirror";
-import { languages } from "@codemirror/language-data";
-import { indentWithTab } from "@codemirror/commands";
-
-import ChakraUIRenderer from "chakra-ui-markdown-renderer";
-import ReactMarkdown from "react-markdown";
-import "./github-markdown-light.css";
-import remarkMath from "remark-math";
-import remarkGfm from "remark-gfm";
-import remarkSimpleUML from "@akebifiky/remark-simple-plantuml";
-import rehypeHighlight from "rehype-highlight";
-import rehypeKatex from "rehype-katex";
-import "katex/dist/katex.min.css";
-
-import Firepad from "@lucafabbian/firepad";
-
-import { useProvideAuth } from "hooks/useAuth";
-import { compatApp } from "config/firebaseConfig";
-import { set, get, getDatabase, ref, serverTimestamp } from "firebase/database";
-import firebase from "firebase/compat/app";
 import "firebase/compat/database";
-
 import EditorNavbar from "./EditorNavbar";
-import SplitPanel from "./SplitPanel";
-
-function MarkdownPreview({ docContent, ...props }: any) {
-  return (
-    <>
-      <ReactMarkdown
-        children={docContent}
-        className="markdown-body"
-        remarkPlugins={[remarkMath, remarkGfm, remarkSimpleUML]}
-        rehypePlugins={[
-          rehypeKatex,
-          [rehypeHighlight, { ignoreMissing: true }],
-        ]}
-      />
-    </>
-  );
-}
+import MarkdownPreview from "./MarkdownPreview";
+import useFirepad from "./useFirepad";
+import LoadingPage from "components/LoadingPage";
 
 const Editor = () => {
   const editorRef = useRef<HTMLDivElement>(null);
   const params = useParams();
-  const navigate = useNavigate();
-  const auth = useProvideAuth();
-  const [view, setView] = useState<EditorView>();
-  const [docContent, setDocContent] = useState("");
-  const [available, setAvailable] = useState<boolean>(false);
+  const { view, docContent, available, userRole } = useFirepad(
+    params.docID,
+    editorRef
+  );
 
-  useEffect(() => {
-    // TODO: Assumes editor is signed in, what if not the case?
-    if (!editorRef.current || !auth.user) return;
-
-    let docRef = "debug_doc";
-
-    if (params.docID) {
-      docRef = "docs/" + params.docID;
-      if (auth.user) {
-        get(ref(getDatabase(), docRef + "/roles/" + auth.user.uid))
-          .then((snapshot) => {
-            if (!snapshot.exists() || snapshot.val() === "viewer") {
-              navigate("/error/403");
-            }
-          })
-          .catch((e) => {
-            if (e.toString() === "Error: Permission denied")
-              navigate("/error/403");
-            else {
-              navigate("/error/" + e);
-            }
-          });
-      }
-      // TODO: Not authenticated case is not yet done.
-    }
-
-    let lastSecond: number = 0;
-
-    const view = new EditorView({
-      extensions: [
-        basicSetup,
-        keymap.of([indentWithTab]),
-        markdown({ base: markdownLanguage, codeLanguages: languages }),
-        EditorView.lineWrapping,
-        EditorView.theme({
-          ".cm-content, .cm-gutter": { fontSize: "14px", minHeight: "92vh" },
-          "&": { height: "calc(100vh - 73px)" },
-          ".cm-scroller": { overflow: "auto" },
-        }),
-        EditorView.updateListener.of((update) => {
-          if (update.changes) {
-            setDocContent(update.state.doc.toString());
-          }
-
-          if (update.docChanged) {
-            // Only update timestamp every second.
-            if (Date.now() - lastSecond >= 1_000) {
-              set(ref(getDatabase(), docRef + "/timestamp"), serverTimestamp());
-              lastSecond = Date.now();
-            }
-          }
-        }),
-      ],
-      parent: editorRef.current,
-    });
-
-    setView(view);
-
-    let firepad = Firepad.fromCodeMirror6(
-      firebase.database(compatApp).ref(docRef),
-      view,
-      {
-        defaultText: "",
-        userId: auth.user.uid,
-      }
-    );
-
-    firepad.on("ready", () => {
-      setAvailable(true);
-    });
-
-    return () => {
-      view.destroy();
-      setView(undefined);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorRef.current, auth.user]);
-
-  /* TODO: Crazy hack solution in terms of top position and calc(100vh - 73px) to get the dimensions exactly right.
+  /* TODO: Crazy hack solution in terms of top position and calc(100vh - 73px) to get the editor dimensions exactly right.
   Seems like a problem waiting to happen in the future...
   */
   return (
@@ -161,18 +37,7 @@ const Editor = () => {
           </Box>
         </VStack>
       </HStack>
-      {!available && (
-        <VStack mt="45vh" spacing="3">
-          <Spinner
-            size="xl"
-            thickness="4px"
-            speed="0.65s"
-            emptyColor="gray.200"
-            color="blue.500"
-          />
-          <Text fontSize="xl">Loading editor...</Text>
-        </VStack>
-      )}
+      {!available && <LoadingPage mt="45vh" msg="Editor loading..." />}
     </Box>
   );
 };

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -343,7 +343,7 @@ function DocShareButton({ docID, ...props }: any) {
                 navigator.clipboard.writeText(window.location.href);
                 setClipboardLabel("Copied!");
                 setTimeout(
-                  () => setClipboardLabel("Copies document link to clipboard"),
+                  () => setClipboardLabel("Copy document link to clipboard."),
                   500
                 );
               }}

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -44,6 +44,7 @@ import { IoShare, IoPersonRemove, IoClipboard } from "react-icons/io5";
 
 import { get, set, onValue, getDatabase, ref } from "firebase/database";
 import { useProvideAuth } from "hooks/useAuth";
+import EditorViewSlider from "./EditorViewSlider";
 
 function validateEmail(email: string) {
   return email.match(
@@ -355,9 +356,14 @@ function DocShareButton({ docID, ...props }: any) {
   );
 }
 
-export default function EditorNavbar({ docID, ...props }: any) {
+export default function EditorNavbar({
+  docID,
+  editSize,
+  setEditSize,
+  ...props
+}: any) {
   return (
-    <NavbarContainer>
+    <NavbarContainer {...props}>
       <Logo
         fontSize="24pt"
         marginBottom="-0.4em"
@@ -368,6 +374,11 @@ export default function EditorNavbar({ docID, ...props }: any) {
         as={RouteLink}
         to="/"
       />
+
+      <Flex align="center" w="40vw">
+        <EditorViewSlider editSize={editSize} setEditSize={setEditSize} />
+      </Flex>
+
       <HStack spacing="4">
         <Flex align="center">
           <DocShareButton docID={docID} />

--- a/conote-frontend/src/components/editor/EditorViewSlider.tsx
+++ b/conote-frontend/src/components/editor/EditorViewSlider.tsx
@@ -1,0 +1,44 @@
+import {
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+  Tooltip,
+  SliderMark,
+} from "@chakra-ui/react";
+import { useState } from "react";
+export default function EditorViewSlider({
+  editSize,
+  setEditSize,
+  ...props
+}: any) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <Slider
+      min={0}
+      max={100}
+      value={editSize}
+      step={5}
+      onChange={(v) => setEditSize(v)}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      aria-label="editor view slider"
+      colorScheme="blue"
+      {...props}
+    >
+      <SliderTrack>
+        <SliderFilledTrack />
+      </SliderTrack>
+      <Tooltip
+        hasArrow
+        colorScheme="blue"
+        placement="top"
+        isOpen={showTooltip}
+        label={`${editSize}%`}
+      >
+        <SliderThumb />
+      </Tooltip>
+    </Slider>
+  );
+}

--- a/conote-frontend/src/components/editor/MarkdownPreview.tsx
+++ b/conote-frontend/src/components/editor/MarkdownPreview.tsx
@@ -1,0 +1,25 @@
+import ChakraUIRenderer from "chakra-ui-markdown-renderer";
+import ReactMarkdown from "react-markdown";
+import "./github-markdown-light.css";
+import remarkMath from "remark-math";
+import remarkGfm from "remark-gfm";
+import remarkSimpleUML from "@akebifiky/remark-simple-plantuml";
+import rehypeHighlight from "rehype-highlight";
+import rehypeKatex from "rehype-katex";
+import "katex/dist/katex.min.css";
+
+export default function MarkdownPreview({ docContent, ...props }: any) {
+  return (
+    <>
+      <ReactMarkdown
+        children={docContent}
+        className="markdown-body"
+        remarkPlugins={[remarkMath, remarkGfm, remarkSimpleUML]}
+        rehypePlugins={[
+          rehypeKatex,
+          [rehypeHighlight, { ignoreMissing: true }],
+        ]}
+      />
+    </>
+  );
+}

--- a/conote-frontend/src/components/editor/github-markdown-light.css
+++ b/conote-frontend/src/components/editor/github-markdown-light.css
@@ -1,3 +1,4 @@
+/* Credits to https://github.com/sindresorhus/github-markdown-css */
 .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -950,8 +951,8 @@
   padding: 45px;
 }
 
-@media (max-width: 767px) {
+/*@media (max-width: 767px) {
   .markdown-body {
     padding: 15px;
   }
-}
+}*/

--- a/conote-frontend/src/components/editor/useFirepad.tsx
+++ b/conote-frontend/src/components/editor/useFirepad.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { compatApp } from "config/firebaseConfig";
+import { set, get, getDatabase, ref, serverTimestamp } from "firebase/database";
+import firebase from "firebase/compat/app";
+
+import { EditorView, keymap } from "@codemirror/view";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { basicSetup } from "codemirror";
+import { languages } from "@codemirror/language-data";
+import { indentWithTab } from "@codemirror/commands";
+
+import Firepad from "@lucafabbian/firepad";
+
+import { useProvideAuth } from "hooks/useAuth";
+
+export default function useFirepad(
+  docID: string | undefined,
+  editorRef: React.RefObject<HTMLDivElement>
+) {
+  const auth = useProvideAuth();
+  const navigate = useNavigate();
+  const [view, setView] = useState<EditorView>();
+  const [docContent, setDocContent] = useState("");
+  const [available, setAvailable] = useState<boolean>(false);
+  const [userRole, setUserRole] = useState<String | undefined>();
+
+  useEffect(() => {
+    // TODO: Assumes editor is signed in, what if not the case?
+    if (!editorRef.current || !auth.user) return;
+
+    let docRef = "debug_doc";
+
+    if (docID) {
+      docRef = "docs/" + docID;
+      if (auth.user) {
+        get(ref(getDatabase(), docRef + "/roles/" + auth.user.uid))
+          .then((snapshot) => {
+            if (!snapshot.exists()) {
+              navigate("/error/403");
+            } else {
+              setUserRole(snapshot.val());
+            }
+          })
+          .catch((e) => {
+            if (e.toString() === "Error: Permission denied")
+              navigate("/error/403");
+            else {
+              navigate("/error/" + e);
+            }
+          });
+      }
+      // TODO: Not authenticated case is not yet done.
+    }
+
+    let lastSecond: number = 0;
+
+    const view = new EditorView({
+      extensions: [
+        basicSetup,
+        keymap.of([indentWithTab]),
+        markdown({ base: markdownLanguage, codeLanguages: languages }),
+        EditorView.lineWrapping,
+        EditorView.theme({
+          ".cm-content, .cm-gutter": { fontSize: "14px", minHeight: "92vh" },
+          "&": { height: "calc(100vh - 73px)" },
+          ".cm-scroller": { overflow: "auto" },
+        }),
+        EditorView.updateListener.of((update) => {
+          if (update.changes) {
+            setDocContent(update.state.doc.toString());
+          }
+
+          if (update.docChanged) {
+            // Only update timestamp every second.
+            if (Date.now() - lastSecond >= 1_000) {
+              set(ref(getDatabase(), docRef + "/timestamp"), serverTimestamp());
+              lastSecond = Date.now();
+            }
+          }
+        }),
+      ],
+      parent: editorRef.current,
+    });
+
+    setView(view);
+
+    let firepad = Firepad.fromCodeMirror6(
+      firebase.database(compatApp).ref(docRef),
+      view,
+      {
+        defaultText: "",
+        userId: auth.user.uid,
+      }
+    );
+
+    firepad.on("ready", () => {
+      setAvailable(true);
+    });
+
+    return () => {
+      view.destroy();
+      setView(undefined);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorRef.current, auth.user]);
+
+  return { view, docContent, available, userRole };
+}

--- a/conote-frontend/src/components/editor/useFirepad.tsx
+++ b/conote-frontend/src/components/editor/useFirepad.tsx
@@ -27,9 +27,7 @@ export default function useFirepad(
   const [userRole, setUserRole] = useState<String | undefined>();
 
   useEffect(() => {
-    // TODO: Assumes editor is signed in, what if not the case?
-    if (!editorRef.current || !auth.user) return;
-
+    if (!auth.user) return;
     let docRef = "debug_doc";
 
     if (docID) {
@@ -53,12 +51,22 @@ export default function useFirepad(
       }
       // TODO: Not authenticated case is not yet done.
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auth.user]);
+
+  useEffect(() => {
+    // TODO: Assumes editor is signed in, what if not the case?
+    if (!editorRef.current || !userRole) return;
+
+    let docRef = "debug_doc";
+    if (docID) docRef = "docs/" + docID;
 
     let lastSecond: number = 0;
-
+    // Remember to doc esc+tab to escape focus.
     const view = new EditorView({
       extensions: [
         basicSetup,
+        EditorView.editable.of(userRole !== "viewer"),
         keymap.of([indentWithTab]),
         markdown({ base: markdownLanguage, codeLanguages: languages }),
         EditorView.lineWrapping,
@@ -91,7 +99,7 @@ export default function useFirepad(
       view,
       {
         defaultText: "",
-        userId: auth.user.uid,
+        userId: auth?.user ? auth.user.uid : undefined,
       }
     );
 
@@ -104,7 +112,7 @@ export default function useFirepad(
       setView(undefined);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorRef.current, auth.user]);
+  }, [editorRef.current, userRole]);
 
   return { view, docContent, available, userRole };
 }

--- a/conote-frontend/src/components/user/Dashboard.tsx
+++ b/conote-frontend/src/components/user/Dashboard.tsx
@@ -12,10 +12,10 @@ export default function Dashboard() {
 
   return (
     auth.user && (
-      <Box minH="100vh">
+      <Box>
         <DashboardNavbar />
 
-        <SimpleGrid minChildWidth="240px" paddingX="7" marginTop="2" gap="5">
+        <SimpleGrid minChildWidth="240px" paddingX="7" marginTop="12vh" gap="5">
           {userData !== undefined &&
             Object.keys(userData.owned_documents).map((item) => {
               return <DocCard docID={item} />;

--- a/conote-frontend/src/components/user/DocCard.tsx
+++ b/conote-frontend/src/components/user/DocCard.tsx
@@ -34,7 +34,20 @@ import { Link as RouteLink } from "react-router-dom";
 import React from "react";
 import { useState, useEffect } from "react";
 import { IoPricetagsSharp, IoTime, IoTrashSharp } from "react-icons/io5";
-import { getDatabase, get, ref, child, remove, update, onValue, set, push, orderByValue, query, equalTo } from "firebase/database";
+import {
+  getDatabase,
+  get,
+  ref,
+  child,
+  remove,
+  update,
+  onValue,
+  set,
+  push,
+  orderByValue,
+  query,
+  equalTo,
+} from "firebase/database";
 import { useProvideAuth } from "hooks/useAuth";
 import { getModularInstance } from "@firebase/util";
 
@@ -104,10 +117,9 @@ function EditTagsButton({ docID, title, ...props }: any) {
 
   useEffect(() => {
     if (!user) return;
-    const unsubscribe = onValue(tagsRef,
-      snapshot => setTags(
-        snapshot.exists() ? snapshot.val() :
-          undefined),
+    const unsubscribe = onValue(
+      tagsRef,
+      (snapshot) => setTags(snapshot.exists() ? snapshot.val() : undefined),
       (e) => {
         // TODO: Alert notification?
         console.log("Tags fetch error: " + e);
@@ -120,8 +132,7 @@ function EditTagsButton({ docID, title, ...props }: any) {
 
   const findTagKey = (value: string) => {
     if (tags !== undefined) {
-      const key = Object.entries(tags)
-        .filter((val) => val[1] === value);
+      const key = Object.entries(tags).filter((val) => val[1] === value);
       return key.length === 0 ? undefined : key[0][0];
     }
     return undefined;
@@ -136,11 +147,10 @@ function EditTagsButton({ docID, title, ...props }: any) {
     if (!user) return;
     let key = findTagKey(value);
     if (key !== undefined) {
-      remove(child(tagsRef, key))
-        .catch(e => {
-          // TODO: Alert notification?
-          console.log("Tags fetch error: " + e);
-        });
+      remove(child(tagsRef, key)).catch((e) => {
+        // TODO: Alert notification?
+        console.log("Tags fetch error: " + e);
+      });
     }
   };
 
@@ -160,10 +170,7 @@ function EditTagsButton({ docID, title, ...props }: any) {
         }}
       />
 
-      <Modal
-        isOpen={isOpen}
-        onClose={onClose}
-      >
+      <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>
@@ -171,30 +178,34 @@ function EditTagsButton({ docID, title, ...props }: any) {
             <ModalCloseButton />
           </ModalHeader>
           <ModalBody>
-            {tags !== undefined && Object.values(tags).map(tag => {
-              return (
-                <Tag>
-                  <TagLabel>{tag}</TagLabel>
-                  <TagCloseButton onClick={() => handleTagDelete(tag)} />
-                </Tag>
-              );
-            })}
+            {tags !== undefined &&
+              Object.values(tags).map((tag) => {
+                return (
+                  <Tag>
+                    <TagLabel>{tag}</TagLabel>
+                    <TagCloseButton onClick={() => handleTagDelete(tag)} />
+                  </Tag>
+                );
+              })}
             <FormControl isInvalid={tagError.length !== 0}>
               <Input
                 autoFocus
                 placeholder="Type new tags here..."
                 value={input}
                 onChange={({ target: { value } }) => {
-                  value = value.replaceAll(',', '').trim();
+                  value = value.replaceAll(",", "").trim();
                   setInput(value);
                 }}
                 onKeyDown={(e) => {
-                  let { key, currentTarget: { value } } = e;
-                  value = value.replaceAll(',', '').trim();
+                  let {
+                    key,
+                    currentTarget: { value },
+                  } = e;
+                  value = value.replaceAll(",", "").trim();
                   switch (key) {
-                    case 'Tab':
-                    case 'Enter':
-                    case ',':
+                    case "Tab":
+                    case "Enter":
+                    case ",":
                       e.preventDefault();
                       if (value.length === 0) {
                         setTagError("Empty tag");
@@ -206,7 +217,7 @@ function EditTagsButton({ docID, title, ...props }: any) {
                         handleTagCreate(value);
                       }
                       break;
-                    case 'Backspace':
+                    case "Backspace":
                       if (value.length === 0) {
                         e.preventDefault();
                         if (tags === undefined) {
@@ -227,13 +238,9 @@ function EditTagsButton({ docID, title, ...props }: any) {
                 variant="outline"
               />
               {tagError.length === 0 ? (
-                <FormHelperText>
-                  Press Enter key to add tag
-                </FormHelperText>
+                <FormHelperText>Press Enter key to add tag</FormHelperText>
               ) : (
-                <FormErrorMessage>
-                  {tagError}
-                </FormErrorMessage>
+                <FormErrorMessage>{tagError}</FormErrorMessage>
               )}
             </FormControl>
           </ModalBody>
@@ -336,7 +343,7 @@ export default function DocCard({ docID, ...props }: any) {
       transition="background-color 100ms linear"
       _hover={{ bgColor: "gray.50" }}
     >
-      <LinkOverlay as={RouteLink} to={"/docs/edit/" + docID}>
+      <LinkOverlay as={RouteLink} to={"/docs/" + docID}>
         <Box
           mt="1"
           fontWeight="semibold"

--- a/conote-frontend/src/components/user/UserButton.tsx
+++ b/conote-frontend/src/components/user/UserButton.tsx
@@ -17,39 +17,41 @@ export default function UserButton(props: any) {
   const auth = useProvideAuth();
 
   return (
-    <Popover placement="bottom-end" autoFocus={false}>
-      <PopoverTrigger>
-        <Avatar
-          bg="blue.400"
-          transition="background-color 100ms linear"
-          _hover={{
-            bg: "blue.600",
-          }}
-          role="button"
-        />
-      </PopoverTrigger>
-      <PopoverContent boxShadow="sm">
-        <PopoverArrow />
-        <PopoverHeader>
-          Hi, <b>{auth.userData === undefined ? "" : auth.userData.fullname}</b>
-          !
-        </PopoverHeader>
-        <PopoverBody>
-          <Button
-            onClick={() => {
-              auth
-                .signout()
-                .then((response: any) => navigate("/"))
-                .catch((error: any) => console.log(error));
+    auth.user && (
+      <Popover placement="bottom-end" autoFocus={false}>
+        <PopoverTrigger>
+          <Avatar
+            bg="blue.400"
+            transition="background-color 100ms linear"
+            _hover={{
+              bg: "blue.600",
             }}
-            colorScheme="blue"
-            boxShadow="base"
-            padding="0px 1.5em"
-          >
-            Logout
-          </Button>
-        </PopoverBody>
-      </PopoverContent>
-    </Popover>
+            role="button"
+          />
+        </PopoverTrigger>
+        <PopoverContent boxShadow="sm">
+          <PopoverArrow />
+          <PopoverHeader>
+            Hi,{" "}
+            <b>{auth.userData === undefined ? "" : auth.userData.fullname}</b>!
+          </PopoverHeader>
+          <PopoverBody>
+            <Button
+              onClick={() => {
+                auth
+                  .signout()
+                  .then((response: any) => navigate("/"))
+                  .catch((error: any) => console.log(error));
+              }}
+              colorScheme="blue"
+              boxShadow="base"
+              padding="0px 1.5em"
+            >
+              Logout
+            </Button>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    )
   );
 }


### PR DESCRIPTION
It does this in a hack-ish solution through the creation of a slider that modifies the panel size of the editor. Currently "the viewer interface" is just the Editor page and checks a user's role, if a user's role is a viewer, it auto sets the slider to 0%, allowing the user to only see the rendered page. Otherwise, it's set to 50%, a splitscreen of both the editor and viewer.

Will open another issue to resolve this hack-ish solution by setting up proper routes perhaps.

Also:
- Modifies editor interface to be more production ready
- Add LoadingPage to be used while waiting for assets / subscriptions.
- As stated above, adds draggable slider to allow user to modify the splitscreen to their liking. Perhaps this will be changed in milestone 3 with a proper draggable divider line.

Closes #38.