### PR TITLE
Fix Timestamp Bug

### DIFF
--- a/conote-frontend/package-lock.json
+++ b/conote-frontend/package-lock.json
@@ -16,7 +16,7 @@
         "@emotion/styled": "^11.8.1",
         "@fontsource/dm-sans": "^4.5.7",
         "@fontsource/league-spartan": "^4.5.10",
-        "@lucafabbian/firepad": "^1.5.16",
+        "@lucafabbian/firepad": "^1.5.17",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
         "@testing-library/user-event": "^13.5.0",
@@ -4881,9 +4881,9 @@
       }
     },
     "node_modules/@lucafabbian/firepad": {
-      "version": "1.5.16",
-      "resolved": "https://registry.npmjs.org/@lucafabbian/firepad/-/firepad-1.5.16.tgz",
-      "integrity": "sha512-ZlSKhfunW9TZDgaEeR/oo8TOla+eb5kwGNPaP48uoOhW40P03pCu8cfRVx8PRrrWByOPVdyfPtQy91//I6HdIw==",
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/@lucafabbian/firepad/-/firepad-1.5.17.tgz",
+      "integrity": "sha512-mf+UPilWsQdksJTt6Lpcl8uABaE5ZMpikC1IQqjANrJSWkvs7ou4yf/ss2VkmxE2UJXOJXVb9dkO1Y/teooc4A==",
       "peerDependencies": {
         "@codemirror/state": "^6.0.0",
         "codemirror": "^6.0.0",
@@ -24973,9 +24973,9 @@
       }
     },
     "@lucafabbian/firepad": {
-      "version": "1.5.16",
-      "resolved": "https://registry.npmjs.org/@lucafabbian/firepad/-/firepad-1.5.16.tgz",
-      "integrity": "sha512-ZlSKhfunW9TZDgaEeR/oo8TOla+eb5kwGNPaP48uoOhW40P03pCu8cfRVx8PRrrWByOPVdyfPtQy91//I6HdIw==",
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/@lucafabbian/firepad/-/firepad-1.5.17.tgz",
+      "integrity": "sha512-mf+UPilWsQdksJTt6Lpcl8uABaE5ZMpikC1IQqjANrJSWkvs7ou4yf/ss2VkmxE2UJXOJXVb9dkO1Y/teooc4A==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/conote-frontend/package.json
+++ b/conote-frontend/package.json
@@ -11,7 +11,7 @@
     "@emotion/styled": "^11.8.1",
     "@fontsource/dm-sans": "^4.5.7",
     "@fontsource/league-spartan": "^4.5.10",
-    "@lucafabbian/firepad": "^1.5.16",
+    "@lucafabbian/firepad": "^1.5.17",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -269,9 +269,7 @@ function PublicViewCheckbox({ docID, isOwner, ...props }: any) {
     const unsub = onValue(
       ref(getDatabase(), `docs/${docID}/public`),
       (snapshot) => {
-        console.log("CAUGHT: " + snapshot.val() + " " + typeof snapshot.val());
         if (snapshot.val() === true) {
-          console.log("TRIGGERED");
           setIsPublic(true);
         } else setIsPublic(false);
       },


### PR DESCRIPTION
Fixes the bug with the following "hacky" solution:
- Adding a boolean flag on page load, so that the first update (when the document loads) does not update the timestamp.
- Add default text to a new note.

However, this introduces a new bug, albeit to a much more minor level
- On an empty note, if a single character is key-ed in, the timestamp is not updated. However, we believe this case is quite minor for real use-cases so we accept this minor bug for now. Perhaps can be fixed in the future?

Please comment if you have a better solution in mind.

Closes #73.