### PR TITLE
Add missing-email error notification to forget-password page

### DIFF
--- a/conote-frontend/src/components/user/ForgetPassword.tsx
+++ b/conote-frontend/src/components/user/ForgetPassword.tsx
@@ -62,6 +62,9 @@ export default function ForgetPassword() {
                   .catch((error) => {
                     let errorTitle = "";
                     switch (error.code) {
+                      case "auth/missing-email":
+                        errorTitle = "Missing email";
+                        break;
                       case "auth/invalid-email":
                         errorTitle = "Invalid email";
                         break;


### PR DESCRIPTION
Closes #61. It seems the documentation [here](https://firebase.google.com/docs/reference/js/v8/firebase.auth.Auth#sendpasswordresetemail) does not mention the `auth/invalid-email` error.