### PR TITLE
Fix Empty Document Title Bug

### DIFF
--- a/conote-frontend/src/components/user/DashboardNavbar.tsx
+++ b/conote-frontend/src/components/user/DashboardNavbar.tsx
@@ -60,7 +60,7 @@ function NewDocButton(props: any) {
         [auth.user.uid]: "owner",
       },
       timestamp: serverTimestamp(),
-      title: title,
+      title: title || "Untitled",
     });
 
     set(

--- a/conote-frontend/src/components/user/DocCard.tsx
+++ b/conote-frontend/src/components/user/DocCard.tsx
@@ -216,10 +216,13 @@ function EditTagsButton({
                 <Input
                   autoFocus
                   placeholder="Document title"
-                  value={title}
+                  defaultValue={title}
                   onChange={({ target: { value } }) => {
-                    set(ref(getDatabase(), `docs/${docID}/title`), value)
-                      .then(() => setTitle(value))
+                    set(
+                      ref(getDatabase(), `docs/${docID}/title`),
+                      value || "Untitled"
+                    )
+                      .then(() => setTitle(value || "Untitled"))
                       .catch((e) => console.log("Set title error: " + e));
                   }}
                   variant="outline"


### PR DESCRIPTION
Closes #87. Replaces empty titles with "Untitled" by default.