### PR TITLE
Fix misc. bugs with documents view

### DIFF
--- a/conote-frontend/src/components/user/Dashboard.tsx
+++ b/conote-frontend/src/components/user/Dashboard.tsx
@@ -159,14 +159,25 @@ export default function Dashboard() {
           />
 
           <SimpleGrid
-            minChildWidth="240px"
+            minChildWidth="300px"
+            maxWidth={`${
+              documents !== undefined
+                ? Object.values(documents).length * 500 + 20
+                : 0
+            }px`}
             paddingX="7"
             marginTop="12vh"
             gap="5"
           >
             {documents !== undefined &&
               Object.values(documents).map((item) => {
-                return <DocCard key={"doc-card-" + item} docID={item} />;
+                return (
+                  <DocCard
+                    key={"doc-card-" + item}
+                    docID={item}
+                    docType={docType}
+                  />
+                );
               })}
           </SimpleGrid>
 

--- a/conote-frontend/src/components/user/DocCard.tsx
+++ b/conote-frontend/src/components/user/DocCard.tsx
@@ -364,7 +364,7 @@ function parseTime(timeStamp: number | undefined): string {
   }
 }
 
-export default function DocCard({ docID, ...props }: any) {
+export default function DocCard({ docID, docType, ...props }: any) {
   const auth = useProvideAuth();
   const [title, setTitle] = useState<string | undefined>(undefined);
   const [timestamp, setTimestamp] = useState<number | undefined>(undefined);
@@ -453,7 +453,7 @@ export default function DocCard({ docID, ...props }: any) {
         <Text>Modified {parseTime(timestamp)} ago</Text>
       </HStack>
       <Flex w="vw" mt="10px" mr="-5px" flexDirection="row-reverse">
-        <DeleteDocButton docID={docID} title={title} />
+        {docType === "owned" && <DeleteDocButton docID={docID} title={title} />}
         <EditTagsButton
           docID={docID}
           title={title}
@@ -461,11 +461,17 @@ export default function DocCard({ docID, ...props }: any) {
           tags={tags}
           setTags={setTags}
         />
-        <Spacer />
-        <HStack mt="1" overflow="hidden">
+        <Spacer minW="10px" />
+        <HStack mt="1" overflow="hidden" borderRadius="xl">
           {tags !== undefined &&
             Object.values(tags).map((tag: any) => {
-              return <ColorfulTag key={docID + "-tag-" + tag} tag={tag} />;
+              return (
+                <ColorfulTag
+                  key={docID + "-tag-" + tag}
+                  tag={tag}
+                  flexShrink={0}
+                />
+              );
             })}
         </HStack>
       </Flex>


### PR DESCRIPTION
Fixes:
- Delete document button is shown on the Shared tab, this shouldn't be the case as editors aren't allowed to erase documents.
- Modifies Document Card Grid to have a maximum width of $(500 \times \text{numOfDocs}) + 20$ pixels. Serviceable solution to deal with the case where there exists a small number of documents and the document card size being exceedingly large. Resolves #23.
- Document Card is now at least 300px wide, which should reduce aggressive overflow issues. As well as modifying the tags to not shrink as its container shrinks. Resolves #70.