### PR TITLE
Add tooltip for tags input

### DIFF
--- a/conote-frontend/src/components/user/DashboardNavbar.tsx
+++ b/conote-frontend/src/components/user/DashboardNavbar.tsx
@@ -28,6 +28,7 @@ import {
   Tabs,
   TabList,
   Tab,
+  Tooltip,
 } from "@chakra-ui/react";
 
 import UserButton from "./UserButton";
@@ -153,7 +154,9 @@ function SortFilterDrawer({
                 </Select>
               </Box>
               <Box>
-                <FormLabel fontWeight="bold">Filter</FormLabel>
+                <Tooltip label='Tags are case insensitive and must be unique'>
+                  <FormLabel fontWeight="bold">Filter</FormLabel>
+                </Tooltip>
                 <VStack>
                   <Container>
                     {tags !== undefined &&

--- a/conote-frontend/src/components/user/DocCard.tsx
+++ b/conote-frontend/src/components/user/DocCard.tsx
@@ -30,12 +30,16 @@ import {
   Container,
   Spacer,
   FormLabel,
+  Tooltip,
+  Icon,
 } from "@chakra-ui/react";
 import { Link as RouteLink } from "react-router-dom";
 import React from "react";
 import { useState, useEffect } from "react";
 import {
   IoCreateSharp,
+  IoInformationCircleSharp,
+  IoInformationOutline,
   IoPricetagsSharp,
   IoTime,
   IoTrashSharp,
@@ -229,7 +233,11 @@ function EditTagsButton({
                 />
               </FormControl>
               <FormControl>
-                <FormLabel>Tags</FormLabel>
+                <FormLabel>
+                  <Tooltip label='Tags are case insensitive and must be unique'>
+                    <Text>Tags</Text>
+                  </Tooltip>
+                </FormLabel>
                 <Container>
                   {tags !== undefined &&
                     Object.values(tags).map((tag: any) => {


### PR DESCRIPTION
Closes #62.

Tooltip is mentioned when hovering on `Tags` header when editing a `DocCard`, or the `Filter` header in the `Sort & Filter Drawer`.