### PR TITLE
Add welcome note on sign up

### DIFF
--- a/conote-frontend/src/hooks/useAuth.tsx
+++ b/conote-frontend/src/hooks/useAuth.tsx
@@ -112,7 +112,7 @@ export function useProvideAuth() {
       })
       .then(async (user) => {
         if (!user) return;
-        const welcomeDocument = '-N7VA2xTdMSXe8UqeUmF';
+        const welcomeDocument = '-N7_A0yVxAjjB-jtlQaN';
         let history = await get(ref(getDatabase(), `docs/${welcomeDocument}/history`))
           .then((snapshot) => {
             console.log(snapshot.val());

--- a/conote-frontend/src/hooks/useAuth.tsx
+++ b/conote-frontend/src/hooks/useAuth.tsx
@@ -24,6 +24,8 @@ import {
   set,
   DataSnapshot,
   onValue,
+  push,
+  serverTimestamp,
 } from "firebase/database";
 import userType from "components/interfaces/userType";
 
@@ -106,6 +108,37 @@ export function useProvideAuth() {
             user.uid
           ).catch((e) => console.log("SetEmailData Error: " + e));
         }
+        return user;
+      })
+      .then(async (user) => {
+        if (!user) return;
+        const welcomeDocument = '-N7VA2xTdMSXe8UqeUmF';
+        let history = await get(ref(getDatabase(), `docs/${welcomeDocument}/history`))
+          .then((snapshot) => {
+            console.log(snapshot.val());
+            return snapshot.val();
+          });
+        const newDocRef = push(ref(getDatabase(), `docs`), {
+          public: false,
+          roles: {
+            [user.uid]: "owner",
+          },
+          tags: {
+            '-': 'conote',
+          },
+          history: history,
+          timestamp: serverTimestamp(),
+          title: "Welcome to coNote!",
+        });
+        set(
+          ref(
+            getDatabase(),
+            `users/${user.uid}/owned_documents/${newDocRef.key}`
+          ),
+          true
+        ).catch((e) => {
+          console.log("Set Error: " + e); // TODO: Alert notification?
+        });
       });
   };
   const signout = () => {


### PR DESCRIPTION
Modify the following line on `useAuth.tsx` to change the welcome note:

```tsx
const welcomeDocument = '-N7VA2xTdMSXe8UqeUmF';
```

The string should link to a public document containing the welcome note. During sign-up, the `history` of `welcomeDocument` will be copied for the (new) user's welcome note.