### PR TITLE
Minor Bug Fixes for Markdown Rendering

### DIFF
--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -154,7 +154,12 @@ const Editor = () => {
             </Allotment.Pane>
 
             <Allotment.Pane visible={panelType !== PanelValue.Edit}>
-              <VStack w="100%" h="100%" overflow="auto">
+              <VStack
+                w="100%"
+                h="100%"
+                overflow="auto"
+                id="markdown-content-container"
+              >
                 <Box w="100%" verticalAlign="top" mt="-23px" textAlign="left">
                   {panelType !== PanelValue.Edit && available && (
                     <MarkdownPreview docContent={docContent} />

--- a/conote-frontend/src/components/editor/Editor.tsx
+++ b/conote-frontend/src/components/editor/Editor.tsx
@@ -156,7 +156,7 @@ const Editor = () => {
             <Allotment.Pane visible={panelType !== PanelValue.Edit}>
               <VStack w="100%" h="100%" overflow="auto">
                 <Box w="100%" verticalAlign="top" mt="-23px" textAlign="left">
-                  {panelType !== PanelValue.Edit && (
+                  {panelType !== PanelValue.Edit && available && (
                     <MarkdownPreview docContent={docContent} />
                   )}
                 </Box>

--- a/conote-frontend/src/components/editor/MarkdownPreview.tsx
+++ b/conote-frontend/src/components/editor/MarkdownPreview.tsx
@@ -27,13 +27,13 @@ function hashchange() {
   const name = "user-content-" + hash;
   const target =
     document.getElementById(name) || document.getElementsByName(name)[0];
+  const container = document.getElementById("markdown-content-container");
 
   if (target) {
     setTimeout(() => {
-      target.scrollIntoView({
+      container?.scroll({
         behavior: "smooth",
-        block: "nearest",
-        inline: "start",
+        top: Math.max(0, target.offsetTop - 10),
       });
     }, 0);
   }


### PR DESCRIPTION
Some minor changes:
- Footnote links now working
- Anchor links are now modified such that "user-content-" is no longer visible in the URL hash. (See rehype-sanitize's FAQ on this).
- Scrolling is now "smooth"