### PR TITLE
Add redirect from document to login page if not signed in

### DIFF
--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -471,18 +471,19 @@ export default function EditorNavbar({
           />
         </HStack>
       </HStack>
-
-      <HStack spacing="4">
-        <HStack align="center" spacing="1">
-          <UserPresenceAvatars userPresence={userPresence} />
-          {userRole !== undefined && userRole !== "viewer" && (
-            <UploadImageButton docID={docID} owner={owner} />
-          )}
-          <ExportButton docContent={docContent} />
-          <DocShareButton docID={docID} />
+      {userRole !== undefined && (
+        <HStack spacing="4">
+          <HStack align="center" spacing="1">
+            <UserPresenceAvatars userPresence={userPresence} />
+            {userRole !== "viewer" && (
+              <UploadImageButton docID={docID} owner={owner} />
+            )}
+            <ExportButton docContent={docContent} />
+            <DocShareButton docID={docID} />
+          </HStack>
+          <UserButton />
         </HStack>
-        <UserButton />
-      </HStack>
+      )}
     </NavbarContainer>
   );
 }

--- a/conote-frontend/src/components/editor/EditorNavbar.tsx
+++ b/conote-frontend/src/components/editor/EditorNavbar.tsx
@@ -55,7 +55,7 @@ function validateEmail(email: string) {
 
 // The following assumes the Owner is never modified from this method.
 async function modifyUserRole(docID: string, uid: string, role: string | null) {
-  let editDocContent = new Promise(() => {});
+  let editDocContent = new Promise(() => { });
 
   if (role === "editor") {
     editDocContent = set(
@@ -287,6 +287,8 @@ function PublicViewCheckbox({ docID, isOwner, ...props }: any) {
   const toast = useToast();
 
   useEffect(() => {
+    if (auth.user === null) return;
+
     const unsub = onValue(
       ref(getDatabase(), `docs/${docID}/public`),
       (snapshot) => {
@@ -342,6 +344,8 @@ function DocShareButton({ docID, ...props }: any) {
 
   // Effect to get user roles.
   useEffect(() => {
+    if (auth.user === null) return;
+
     const unsub = onValue(
       ref(getDatabase(), `docs/${docID}/roles`),
       (snapshot) => {
@@ -471,7 +475,7 @@ export default function EditorNavbar({
       <HStack spacing="4">
         <HStack align="center" spacing="1">
           <UserPresenceAvatars userPresence={userPresence} />
-          {userRole !== "viewer" && (
+          {userRole !== undefined && userRole !== "viewer" && (
             <UploadImageButton docID={docID} owner={owner} />
           )}
           <ExportButton docContent={docContent} />

--- a/conote-frontend/src/components/interfaces/queryStringType.tsx
+++ b/conote-frontend/src/components/interfaces/queryStringType.tsx
@@ -1,0 +1,3 @@
+export default interface queryStringType {
+  continueUrl: string,
+}

--- a/conote-frontend/src/components/user/Dashboard.tsx
+++ b/conote-frontend/src/components/user/Dashboard.tsx
@@ -204,8 +204,8 @@ export default function Dashboard() {
 
 function NoDocumentComponent({ docType, ...props }: any) {
   const auth = useProvideAuth();
-  const hasOwned = auth.userData !== undefined && Object.keys(auth.userData.owned_documents).length !== 0;
-  const hasShared = auth.userData !== undefined && Object.keys(auth.userData.shared_documents).length !== 0;
+  const hasOwned = auth.userData !== undefined && auth.userData.owned_documents !== undefined && Object.keys(auth.userData.owned_documents).length !== 0;
+  const hasShared = auth.userData !== undefined && auth.userData.shared_documents !== undefined && Object.keys(auth.userData.shared_documents).length !== 0;
 
   return (
     <VStack

--- a/conote-frontend/src/components/user/Login.tsx
+++ b/conote-frontend/src/components/user/Login.tsx
@@ -10,12 +10,13 @@ import {
   Button,
   useToast,
 } from "@chakra-ui/react";
-import { Link as RouteLink } from "react-router-dom";
+import { Link as RouteLink, useLocation } from "react-router-dom";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useProvideAuth } from "hooks/useAuth";
 import PasswordInput from "./PasswordInput";
 import { Helmet } from "react-helmet";
+import queryStringType from "components/interfaces/queryStringType";
 
 function LoginForm(props: any) {
   const [email, setEmail] = useState("");
@@ -63,6 +64,7 @@ function LoginForm(props: any) {
 export default function Login() {
   const toast = useToast();
   const navigate = useNavigate();
+  const location = useLocation();
   const authentication = useProvideAuth();
 
   return (
@@ -80,7 +82,12 @@ export default function Login() {
               authentication
                 .signin(email, password)
                 .then((response) => {
-                  navigate("/dashboard");
+                  if (location.state) {
+                    let { continueUrl } = location.state as queryStringType;
+                    navigate(continueUrl);
+                  } else {
+                    navigate("/dashboard");
+                  }
                   toast({
                     title: "Logged in!",
                     status: "success",


### PR DESCRIPTION
Notes:
- If currently user is not signed in, and user attempted to access non-public document, user will be redirected to login page. Upon successful login, user will be redirected back to the document link. If the user is still prohibited from accessing the document (e.g. logged in to the wrong account), user will be redirected to an error page as before.

Closes #55.